### PR TITLE
Add restricted blanket impls for Clone and Debug. Use associated functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "changed"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Simple change detection"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 use changed::Cd;
 
 // Create the change tracker with an i32
-let mut test: Changed<i32> = Changed::new(20);
+let mut test: Cd<i32> = Cd::new(20);
 
 // Mutate it (calling deref_mut through the *)
 *test += 5;
@@ -23,8 +23,10 @@ assert_eq!(*test, 25);
 assert!(!test.changed());
 ```
 
-## How it works
-Technically, it doesn't track changes. It tracks calls to `deref_mut()`
-so it is entirely possible to call `deref_mut()` and not change it, giving a false positive.
+## How It Works
+Technically, it doesn't track changes. It tracks calls to `deref_mut()` so it is
+entirely possible to call `deref_mut()` and not change it, giving a false
+positive.
 
-Along with that, there is a function to mutate a `Cd` without tripping change detection. 
+Along with that, there is a function to mutate a `Cd` without tripping change
+detection.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,13 @@
 //! ```
 //! 
 //! ## How it works
-//! Technically, it doesn't track changes. It tracks calls to `deref_mut()`
-//! so it is entirely possible to call `deref_mut()` and not change it, giving a false positive.
+//!
+//! Technically, it doesn't track changes. It tracks calls to `deref_mut()` so
+//! it is entirely possible to call `deref_mut()` and not change it, giving a
+//! false positive.
 //! 
-//! Along with that, there is a function to mutate a `Cd` without tripping change detection. 
+//! Along with that, the function `silent_mut()` can mutate a `Cd` without
+//! tripping change detection.
 
 use std::ops::{Deref, DerefMut};
 use std::fmt;
@@ -68,7 +71,6 @@ impl<T> Cd<T> {
             changed: true,
         }
     }
-
 
     /// Reset the change tracking to false.
     /// ```
@@ -150,7 +152,7 @@ impl<T> DerefMut for Cd<T> {
     }
 }
 
-/// Impl default where the data impls default. Change detection is initialized to false.
+/// Impl Default where the data impls Default. Change detection is initialized to false.
 /// ```
 /// use changed::Cd;
 /// // 0 is default for i32.
@@ -163,6 +165,16 @@ impl<T: Default> Default for Cd<T> {
     }
 }
 
+/// Impl Clone where the data impls Clone. Change flag is copied from source.
+/// ```
+/// use changed::Cd;
+/// // 0 is default for i32.
+/// let mut name: Cd<String> = Cd::new("Hi".into());
+/// name.push('!');
+/// let clone = name.clone();
+/// assert!(Cd::changed(&name));
+/// assert!(Cd::changed(&clone));
+/// ```
 impl <T: Clone> Clone for Cd<T> {
     fn clone(&self) -> Self {
         Cd {
@@ -172,6 +184,12 @@ impl <T: Clone> Clone for Cd<T> {
     }
 }
 
+/// Impl Debug where the data impls Debug.
+/// ```
+/// use changed::Cd;
+/// let zero: Cd<i32> = Cd::default();
+/// assert_eq!("Cd { data: 0, changed: false }", format!("{:?}", &zero));
+/// ```
 impl <T: fmt::Debug> fmt::Debug for Cd<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Cd").field("data", &self.data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,16 +11,16 @@
 //! *test += 5;
 //! 
 //! // changed() reports whether or not it was changed
-//! assert!(test.changed());
+//! assert!(Cd::changed(&test));
 //! 
 //! // Reset the tracker back to false
-//! test.reset();
+//! Cd::reset(&mut test);
 //! 
 //! // Read the data
 //! assert_eq!(*test, 25);
 //! 
 //! // That didn't trip the change detection!
-//! assert!(!test.changed());
+//! assert!(!Cd::changed(&test));
 //! ```
 //! 
 //! ## How it works
@@ -60,7 +60,7 @@ impl<T> Cd<T> {
     /// ```
     /// use changed::Cd;
     /// let cd = Cd::new_true(5);
-    /// assert!(cd.changed());
+    /// assert!(Cd::changed(&cd));
     /// ```
     pub fn new_true(data: T) -> Cd<T> {
         Cd {
@@ -69,53 +69,55 @@ impl<T> Cd<T> {
         }
     }
 
+
     /// Reset the change tracking to false.
     /// ```
     /// use changed::Cd;
     /// let mut cd = Cd::new_true(5);
-    /// cd.reset();
-    /// assert!(!cd.changed());
+    /// Cd::reset(&mut cd);
+    /// assert!(!Cd::changed(&cd));
     /// ```
-    pub fn reset(&mut self) {
-        self.changed = false;
+    pub fn reset(this: &mut Cd<T>) {
+        this.changed = false;
     }
 
     /// Take the data out of the Cd.
-    /// Consumes self and returns data.
+    /// Consumes this and returns data.
     /// ```
     /// use changed::Cd;
     /// let cd = Cd::new(5);
-    /// let data = cd.take();
+    /// let data = Cd::take(cd);
     /// // Error: cd has been moved.
-    /// // cd.changed();
+    /// // Cd::changed(&cd);
     /// ```
-    pub fn take(self) -> T {
-        self.data
+    pub fn take(this: Cd<T>) -> T {
+        this.data
     }
 
     /// Check if the Cd has been changed since the last call to reset (or created.)
     /// ```
     /// use changed::Cd;
     /// let mut cd = Cd::new(5);
-    /// assert!(!cd.changed());
+    /// assert!(!Cd::changed(&cd));
     /// *cd += 5;
-    /// assert!(cd.changed());
+    /// assert!(Cd::changed(&cd));
     /// ```
-    pub fn changed(&self) -> bool {
-        self.changed
+    pub fn changed(this: &Cd<T>) -> bool {
+        this.changed
     }
 
     /// Mutate the Cd without tripping change detection.
-    /// 
+    ///
     /// ```
     /// use changed::Cd;
     /// let mut cd = Cd::new(5);
-    /// *cd.mutate_silently() += 5;
-    /// assert!(!cd.changed());
+    /// *Cd::silent_mut(&mut cd) += 5;
+    /// assert!(!Cd::changed(&cd));
     /// ```
-    pub fn mutate_silently(&mut self) -> &mut T {
-        &mut self.data
+    pub fn silent_mut(this: &mut Cd<T>) -> &mut T {
+        &mut this.data
     }
+
 }
 
 /// deref does not trip change detection.
@@ -123,7 +125,7 @@ impl<T> Cd<T> {
 /// use changed::Cd;
 /// let cd = Cd::new(5);
 /// assert_eq!(*cd, 5); // deref for == 5
-/// assert!(!cd.changed()); // .changed() is false
+/// assert!(!Cd::changed(&cd)); // .changed() is false
 /// ```
 impl<T> Deref for Cd<T> {
     type Target = T;
@@ -139,7 +141,7 @@ impl<T> Deref for Cd<T> {
 /// let mut cd = Cd::new(5);
 /// *cd += 5; // deref_mut for add assign
 /// assert_eq!(*cd, 10);
-/// assert!(cd.changed()); // .changed() is true
+/// assert!(Cd::changed(&cd)); // .changed() is true
 /// ```
 impl<T> DerefMut for Cd<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -153,7 +155,7 @@ impl<T> DerefMut for Cd<T> {
 /// use changed::Cd;
 /// // 0 is default for i32.
 /// let zero: Cd<i32> = Cd::default();
-/// assert!(!zero.changed());
+/// assert!(!Cd::changed(&zero));
 /// ```
 impl<T: Default> Default for Cd<T> {
     fn default() -> Self {
@@ -183,11 +185,11 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let mut changed = Cd::new(15);
-        *changed += 5;
-        assert!(changed.changed);
-        changed.reset();
-        assert_eq!(*changed, 20);
-        assert!(!changed.changed);
+        let mut cd = Cd::new(15);
+        *cd += 5;
+        assert!(Cd::changed(&cd));
+        Cd::reset(&mut cd);
+        assert_eq!(*cd, 20);
+        assert!(!Cd::changed(&cd));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! Along with that, there is a function to mutate a `Cd` without tripping change detection. 
 
 use std::ops::{Deref, DerefMut};
+use std::fmt;
 
 /// Cd: Change Detection
 ///
@@ -157,6 +158,22 @@ impl<T> DerefMut for Cd<T> {
 impl<T: Default> Default for Cd<T> {
     fn default() -> Self {
         Cd::new(T::default())
+    }
+}
+
+impl <T: Clone> Clone for Cd<T> {
+    fn clone(&self) -> Self {
+        Cd {
+            data: self.data.clone(),
+            changed: self.changed
+        }
+    }
+}
+
+impl <T: fmt::Debug> fmt::Debug for Cd<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Cd").field("data", &self.data)
+                            .field("changed", &self.changed).finish()
     }
 }
 


### PR DESCRIPTION
Thank you for this package. I had been pondering what a solution for change detection might look like in rust, and I was kind of blown away by how concisely it was captured by your package. [I posted about it.](https://mastodon.gamedev.place/@shanecelis/110470704559995620) In using it, I made some changes.

I added some restricted blanket impls for Clone and Debug along with a doc and test. [Rust recommends not having any inherent methods for smart pointers](https://rust-lang.github.io/api-guidelines/predictability.html#c-smart-ptr), so I followed their recommendation and converted them to associated functions. 

I changed `mutate_silently` to `silent_mut`. It seemed more in line with rust's naming conventions.

I bumped the minor version number. It's actually a breaking change and should technically require a major version number bump but often for young packages it seems too early to bump the major one.